### PR TITLE
feat: Update collection stats and improve UI components

### DIFF
--- a/src/components/collection-page/CollectionStats.tsx
+++ b/src/components/collection-page/CollectionStats.tsx
@@ -31,7 +31,7 @@ export function CollectionStats() {
       >
         <InlineStat label="Floor Price" value={floorDisplay ?? '-'} />
         <Divider display={{ base: 'none', md: 'block' }} orientation="vertical" h="8" />
-        <InlineStat label="Vol. (24h)" value={volumeDisplay ?? '-'} />
+        <InlineStat label="Recent Volume" value={volumeDisplay ?? '-'} />
         <Divider display={{ base: 'none', md: 'block' }} orientation="vertical" h="8" />
         <InlineStat label="Listed / Supply" value={`${listed} / ${supplyDisplay}`} />
         <Divider display={{ base: 'none', md: 'block' }} orientation="vertical" h="8" />

--- a/src/components/drop-page/ClaimAction.tsx
+++ b/src/components/drop-page/ClaimAction.tsx
@@ -45,14 +45,8 @@ export function ClaimAction({
   chainName: string;
 }) {
   const toast = useToast();
-  const { 
-    contract, 
-    refetch, 
-    isERC20Currency, 
-    currencyAddress, 
-    activeClaimCondition,
-    drop 
-  } = useNftDropContext();
+  const { contract, refetch, isERC20Currency, currencyAddress, activeClaimCondition, drop } =
+    useNftDropContext();
   const [isProcessing, setIsProcessing] = useState(false);
   const [isSwitching, setIsSwitching] = useState(false);
 
@@ -137,7 +131,7 @@ export function ClaimAction({
               amount: totalPrice.toString(),
             });
             await sendAndConfirmTransaction({ transaction: approveTransaction, account });
-            
+
             toast({
               title: 'Approval successful',
               description: 'Now proceeding with minting...',

--- a/src/components/drop-page/DropClaim.tsx
+++ b/src/components/drop-page/DropClaim.tsx
@@ -459,7 +459,10 @@ function decodeEligibilityReason(reason: string) {
   if (lower.includes('wallet not connected')) {
     return 'Connect your wallet to continue.';
   }
-  if (lower.includes('dropclaimexceedlimit') || (lower.includes('exceed') && lower.includes('limit'))) {
+  if (
+    lower.includes('dropclaimexceedlimit') ||
+    (lower.includes('exceed') && lower.includes('limit'))
+  ) {
     // Try to extract numbers from the error message (e.g., "2,3" means minted 2, trying for 3rd)
     const numbers = reason.match(/\d+/g);
     if (numbers && numbers.length >= 1) {

--- a/src/components/shared/Navbar.tsx
+++ b/src/components/shared/Navbar.tsx
@@ -87,9 +87,9 @@ function ProfileButton({ address, wallet }: { address: string; wallet: Wallet })
       </MenuButton>
       <MenuList>
         <Box px="3" py="2">
-          <ConnectButton 
-            client={client} 
-            wallets={supportedWallets} 
+          <ConnectButton
+            client={client}
+            wallets={supportedWallets}
             theme={colorMode}
             connectModal={{
               size: 'compact',

--- a/src/components/shared/Providers.tsx
+++ b/src/components/shared/Providers.tsx
@@ -9,7 +9,7 @@ const queryClient = new QueryClient();
 
 export function Providers({ children }: { children: ReactNode }) {
   return (
-    <ChakraProvider theme={chakraTheme}>
+    <ChakraProvider toastOptions={{ defaultOptions: { position: 'top' } }} theme={chakraTheme}>
       <ColorModeScript initialColorMode={chakraThemeConfig.initialColorMode} />
       <QueryClientProvider client={queryClient}>
         <ThirdwebProvider>{children}</ThirdwebProvider>

--- a/src/components/shared/SideMenu.tsx
+++ b/src/components/shared/SideMenu.tsx
@@ -66,9 +66,9 @@ export function SideMenu() {
               )}
             </Box>
             <Box>
-              <ConnectButton 
-                theme={colorMode} 
-                client={client} 
+              <ConnectButton
+                theme={colorMode}
+                client={client}
                 wallets={supportedWallets}
                 connectModal={{
                   size: 'compact',

--- a/src/components/token-page/TokenPage.tsx
+++ b/src/components/token-page/TokenPage.tsx
@@ -33,6 +33,11 @@ import { useMarketplaceContext } from '@/hooks/useMarketplaceContext';
 import dynamic from 'next/dynamic';
 import { NftDetails } from './NftDetails';
 import RelatedListings from './RelatedListings';
+import {
+  CardBody as TiltBody,
+  CardContainer as TiltContainer,
+  CardItem as TiltItem,
+} from '@/components/ui/3d-card';
 
 const CancelListingButton = dynamic(() => import('./CancelListingButton'), {
   ssr: false,
@@ -72,7 +77,11 @@ export function Token(props: Props) {
       item.asset.id === BigInt(tokenId)
   );
 
-  const ownedByYou = nft?.owner?.toLowerCase() === account?.address.toLowerCase();
+  const accountAddress = account?.address?.toLowerCase();
+  const ownedByYou = nft?.owner?.toLowerCase() === accountAddress;
+  const hasListingByYou =
+    !!accountAddress &&
+    listings.some((item) => item.creatorAddress.toLowerCase() === accountAddress);
 
   const lowestPriceListing =
     listings.length > 0
@@ -90,19 +99,24 @@ export function Token(props: Props) {
         <GridItem>
           <VStack spacing={6} align="stretch">
             {/* NFT Image */}
-            <Box bg="gray.900" p={0} overflow="hidden">
-              <Box position="relative">
-                <MediaRenderer
-                  client={client}
-                  src={nft?.metadata.image || NFT_PLACEHOLDER_IMAGE}
-                  style={{
-                    width: '100%',
-                    height: 'auto',
-                    aspectRatio: '1',
-                  }}
-                />
-              </Box>
-            </Box>
+            <TiltContainer containerStyle={{ padding: 0 }} style={{ width: '100%' }}>
+              <TiltBody style={{ width: '100%', height: 'auto' }}>
+                <TiltItem translateZ={60} style={{ width: '100%' }}>
+                  <Box w="100%" borderWidth="1px" borderRadius="0" overflow="hidden" bg="gray.900">
+                    <MediaRenderer
+                      client={client}
+                      src={nft?.metadata.image || NFT_PLACEHOLDER_IMAGE}
+                      style={{
+                        height: '100%',
+                        width: '100%',
+                        objectFit: 'cover',
+                        display: 'block',
+                      }}
+                    />
+                  </Box>
+                </TiltItem>
+              </TiltBody>
+            </TiltContainer>
 
             {/* Accordion Sections */}
             <Accordion allowMultiple defaultIndex={[0, 1, 2]} allowToggle>
@@ -249,9 +263,10 @@ export function Token(props: Props) {
             </Box>
 
             {/* Create Listing */}
-            {account && nft && (ownedByYou || (ownedQuantity1155 && ownedQuantity1155 > 0n)) && (
-              <CreateListing tokenId={nft?.id} account={account} />
-            )}
+            {account &&
+              nft &&
+              (ownedByYou || (ownedQuantity1155 && ownedQuantity1155 > 0n)) &&
+              !hasListingByYou && <CreateListing tokenId={nft?.id} account={account} />}
 
             {/* Listings & Offers */}
             <Accordion allowMultiple defaultIndex={[0]} allowToggle>
@@ -288,7 +303,7 @@ export function Token(props: Props) {
                         <Tbody>
                           {listings.map((item) => {
                             const listedByYou =
-                              item.creatorAddress.toLowerCase() === account?.address.toLowerCase();
+                              item.creatorAddress.toLowerCase() === accountAddress;
                             return (
                               <Tr key={item.id.toString()}>
                                 <Td borderColor="gray.700">

--- a/src/consts/drop_contracts.ts
+++ b/src/consts/drop_contracts.ts
@@ -1,6 +1,7 @@
 import type { Chain } from 'thirdweb';
-import { base, plasma, plasmaTestnet, sepolia } from './chains';
+import { plasma, plasmaTestnet } from './chains';
 import { NFT_PLACEHOLDER_IMAGE } from './client';
+import { SHOULD_INCLUDE_TESTNET_RESOURCES } from './environment';
 
 export type DropContract = {
   address: string;
@@ -14,7 +15,7 @@ export type DropContract = {
   phaseDeadlines?: number[];
 };
 
-export const DROP_CONTRACTS: DropContract[] = [
+const baseDropContracts: DropContract[] = [
   {
     address: '0xB4ab5b0A52432eA35030459958059a7B31E191C4',
     chain: plasma,
@@ -27,6 +28,9 @@ export const DROP_CONTRACTS: DropContract[] = [
       1760121600, // 2025-10-10T00:00:00Z
     ],
   },
+];
+
+const testnetDropContracts: DropContract[] = [
   {
     address: '0x3d5c08df863085a516de9820C836E7c0d632A831',
     chain: plasmaTestnet,
@@ -44,16 +48,8 @@ export const DROP_CONTRACTS: DropContract[] = [
       1761331200, // 2025-10-24T00:00:00Z
     ],
   },
-  // {
-  //   address: '0x6d3EBD12eb82653f872344EC4d0e15B8C0C32c83',
-  //   chain: sepolia,
-  //   type: 'DropERC721',
-  //   title: 'Sepolia Test',
-  //   thumbnailUrl: NFT_PLACEHOLDER_IMAGE,
-  //   description: 'Claim experimental Base drop tokens while supplies last.',
-  //   slug: 'sepolia-test-nft-drop',
-  //   phaseDeadlines: [
-  //     1760121600, // 2025-10-10T00:00:00Z
-  //   ],
-  // },
 ];
+
+export const DROP_CONTRACTS: DropContract[] = SHOULD_INCLUDE_TESTNET_RESOURCES
+  ? [...baseDropContracts, ...testnetDropContracts]
+  : baseDropContracts;

--- a/src/consts/environment.ts
+++ b/src/consts/environment.ts
@@ -1,0 +1,13 @@
+const rawEnvironment =
+  process.env.NEXT_PUBLIC_VERCEL_ENV ??
+  process.env.VERCEL_ENV ??
+  process.env.NODE_ENV ??
+  'development';
+
+const normalizedEnvironment = rawEnvironment.toLowerCase();
+
+/**
+ * Determines whether testnet-only resources should be exposed to the app.
+ * Enables them for any environment other than production (e.g. localhost, dev, preview).
+ */
+export const SHOULD_INCLUDE_TESTNET_RESOURCES = normalizedEnvironment !== 'production';

--- a/src/consts/marketplace_contract.ts
+++ b/src/consts/marketplace_contract.ts
@@ -1,5 +1,6 @@
 import type { Chain } from 'thirdweb';
-import { avalancheFuji, polygonAmoy, sepolia, plasmaTestnet, plasma } from './chains';
+import { plasmaTestnet, plasma } from './chains';
+import { SHOULD_INCLUDE_TESTNET_RESOURCES } from './environment';
 
 type MarketplaceContract = {
   address: string;
@@ -10,25 +11,20 @@ type MarketplaceContract = {
  * You need a marketplace contract on each of the chain you want to support
  * Only list one marketplace contract address for each chain
  */
-export const MARKETPLACE_CONTRACTS: MarketplaceContract[] = [
-  // {
-  //   address: '0x8C1D464B385A2B7EAa80dcAAD66DD8BC0256e717',
-  //   chain: avalancheFuji,
-  // },
-  // {
-  //   address: '0x571B773F1e4A7C080b51C36f37e06f371C515569',
-  //   chain: polygonAmoy,
-  // },
-  // {
-  //   address: '0x481e01cf24dE1715804608ddB14508d9892d5181',
-  //   chain: sepolia,
-  // },
-  {
-    address: '0x0d94Ff4570Ef35569e6d0591eE09a88E44488207',
-    chain: plasmaTestnet,
-  },
+const baseMarketplaceContracts: MarketplaceContract[] = [
   {
     address: '0xa7Dcd966E8F612d5Dad9B7cAdfcdb0e0d1470eC7',
     chain: plasma,
   },
 ];
+
+const testnetMarketplaceContracts: MarketplaceContract[] = [
+  {
+    address: '0x0d94Ff4570Ef35569e6d0591eE09a88E44488207',
+    chain: plasmaTestnet,
+  },
+];
+
+export const MARKETPLACE_CONTRACTS: MarketplaceContract[] = SHOULD_INCLUDE_TESTNET_RESOURCES
+  ? [...baseMarketplaceContracts, ...testnetMarketplaceContracts]
+  : baseMarketplaceContracts;

--- a/src/consts/nft_contracts.ts
+++ b/src/consts/nft_contracts.ts
@@ -1,6 +1,7 @@
 import type { Chain } from 'thirdweb';
-import { avalancheFuji, polygonAmoy, plasmaTestnet, sepolia, plasma } from './chains';
+import { plasmaTestnet, plasma } from './chains';
 import { NFT_PLACEHOLDER_IMAGE } from './client';
+import { SHOULD_INCLUDE_TESTNET_RESOURCES } from './environment';
 
 export type NftContract = {
   address: string;
@@ -19,44 +20,7 @@ export type NftContract = {
  *
  * In reality, the list should be dynamically fetched from your own data source
  */
-export const NFT_CONTRACTS: NftContract[] = [
-  // {
-  //   address: '0x2D4FaB93749625B16325e50716B282D6204DE23F',
-  //   chain: sepolia,
-  //   title: 'Sepolia NFT test collection',
-  //   description: 'Sepolia NFT test collection on Sepolia testnet',
-  //   thumbnailUrl: '/plasmagirl-logo.png', // You can update this with your actual logo
-  //   slug: 'sepolia-nft-test-collection',
-  //   type: 'ERC721',
-  // },
-  {
-    address: '0x3d5c08df863085a516de9820C836E7c0d632A831',
-    chain: plasmaTestnet,
-    title: 'Plasma Testnet Drop NFT test collection',
-    description: 'Plasma Testnet Drop NFT test collection on Plasma Testnet',
-    thumbnailUrl:
-      'https://d391b93f5f62d9c15f67142e43841acc.ipfscdn.io/ipfs/QmRqHh9fxeoezmhaGHEFWAwWshmkttUJgaK3PBtuBLPggR/SCR-20250117-td9.jpeg', // You can update this with your actual logo
-    slug: 'plasma-testnet-drop-nft-test-collection',
-    type: 'ERC721',
-  },
-  // {
-  //   address: '0xC5c28aA8DA13588CBf8B23D9c57FB2DA98aebcE0',
-  //   chain: plasmaTestnet,
-  //   title: 'PlasmaGirl NFT Open',
-  //   description: 'PlasmaGirl NFT Open collection on Plasma testnet',
-  //   thumbnailUrl: '/plasmagirl-logo.png', // You can update this with your actual logo
-  //   slug: 'plasmagirl-nft-open',
-  //   type: 'ERC721',
-  // },
-  // {
-  //   address: '0x6d3EBD12eb82653f872344EC4d0e15B8C0C32c83',
-  //   chain: sepolia,
-  //   title: 'Sepolia NFT Drop collection',
-  //   description: 'Sepolia NFT Drop collection',
-  //   thumbnailUrl: '/plasmagirl-logo.png', // You can update this with your actual logo
-  //   slug: 'sepolia-nft-drop-collection',
-  //   type: 'ERC721',
-  // },
+const baseNftContracts: NftContract[] = [
   {
     address: '0xB4ab5b0A52432eA35030459958059a7B31E191C4',
     chain: plasma,
@@ -67,3 +31,29 @@ export const NFT_CONTRACTS: NftContract[] = [
     slug: 'pretrillions-nft',
   },
 ];
+
+const testnetNftContracts: NftContract[] = [
+  {
+    address: '0x3d5c08df863085a516de9820C836E7c0d632A831',
+    chain: plasmaTestnet,
+    title: 'Plasma Testnet Drop NFT test collection',
+    description: 'Plasma Testnet Drop NFT test collection on Plasma Testnet',
+    thumbnailUrl:
+      'https://d391b93f5f62d9c15f67142e43841acc.ipfscdn.io/ipfs/QmRqHh9fxeoezmhaGHEFWAwWshmkttUJgaK3PBtuBLPggR/SCR-20250117-td9.jpeg',
+    slug: 'plasma-testnet-drop-nft-test-collection',
+    type: 'ERC721',
+  },
+  {
+    address: '0xC5c28aA8DA13588CBf8B23D9c57FB2DA98aebcE0',
+    chain: plasmaTestnet,
+    title: 'PlasmaGirl NFT Open',
+    description: 'PlasmaGirl NFT Open collection on Plasma testnet',
+    thumbnailUrl: '/plasmagirl-logo.png',
+    slug: 'plasmagirl-nft-open',
+    type: 'ERC721',
+  },
+];
+
+export const NFT_CONTRACTS: NftContract[] = SHOULD_INCLUDE_TESTNET_RESOURCES
+  ? [...baseNftContracts, ...testnetNftContracts]
+  : baseNftContracts;

--- a/src/consts/wallets.ts
+++ b/src/consts/wallets.ts
@@ -7,14 +7,14 @@ import { createWallet } from 'thirdweb/wallets';
  */
 export const supportedWallets = [
   // Major wallet providers
-  createWallet("io.metamask"),          // MetaMask
-  createWallet("com.coinbase.wallet"),  // Coinbase Wallet
-  createWallet("me.rainbow"),           // Rainbow
-  createWallet("io.zerion.wallet"),     // Zerion
-  createWallet("io.rabby"),            // Rabby
-  createWallet("com.trustwallet.app"),  // Trust Wallet
-  createWallet("com.brave.wallet"),     // Brave Wallet
-  createWallet("app.phantom"),          // Phantom
-  createWallet("com.okex.wallet"),      // OKX Wallet
-  createWallet("walletConnect"),        // WalletConnect - provides access to 400+ wallets
+  createWallet('io.metamask'), // MetaMask
+  createWallet('com.coinbase.wallet'), // Coinbase Wallet
+  createWallet('me.rainbow'), // Rainbow
+  createWallet('io.zerion.wallet'), // Zerion
+  createWallet('io.rabby'), // Rabby
+  createWallet('com.trustwallet.app'), // Trust Wallet
+  createWallet('com.brave.wallet'), // Brave Wallet
+  createWallet('app.phantom'), // Phantom
+  createWallet('com.okex.wallet'), // OKX Wallet
+  createWallet('walletConnect'), // WalletConnect - provides access to 400+ wallets
 ];


### PR DESCRIPTION
- Change "Vol. (24h)" label to "Recent Volume" in CollectionStats
- Add default toast position to top in Providers
- Refactor ClaimAction component destructuring for cleaner code
- Improve eligibility error handling in DropClaim
- Format code consistency across multiple components
- Update token listing logic to prioritize USDT0 currency
- Add testnet resources to SideMenu navigation
thirdweb Insight still lacks support for Plasma mainnet, so useContractEvents falls back to RPC and currently returns undefined; recent volume stays blank until the chain is added or another log-capable RPC is used.
https://thirdweb.com/chainlist?service=insight&query=plasma