### PR TITLE
Hotfix: Fix USDT0 logo display using Next.js Image

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,8 +21,8 @@ import {
   Stack,
   Button,
   Badge,
-  Image,
 } from '@chakra-ui/react';
+import Image from 'next/image';
 import { getContract } from 'thirdweb';
 import { getContractMetadata } from 'thirdweb/extensions/common';
 import {
@@ -197,7 +197,15 @@ function CollectionCard({ item }: { item: NftContract }) {
               ) : (
                 <HStack spacing={1}>
                   {floorDisplay && floorDisplay !== 'N/A' && (
-                    <Image src="/erc20-icons/usdt0_logo.png" alt="USDT0" boxSize="14px" />
+                    <Box position="relative" width="14px" height="14px" flexShrink={0}>
+                      <Image 
+                        src="/erc20-icons/usdt0_logo.png" 
+                        alt="USDT0" 
+                        fill
+                        sizes="14px"
+                        style={{ objectFit: 'contain' }}
+                      />
+                    </Box>
                   )}
                   <Text fontWeight="bold" fontSize="sm" color="white">
                     {floorDisplay ?? 'N/A'}
@@ -214,7 +222,15 @@ function CollectionCard({ item }: { item: NftContract }) {
               ) : (
                 <HStack spacing={1}>
                   {volumeDisplay && volumeDisplay !== 'N/A' && (
-                    <Image src="/erc20-icons/usdt0_logo.png" alt="USDT0" boxSize="14px" />
+                    <Box position="relative" width="14px" height="14px" flexShrink={0}>
+                      <Image 
+                        src="/erc20-icons/usdt0_logo.png" 
+                        alt="USDT0" 
+                        fill
+                        sizes="14px"
+                        style={{ objectFit: 'contain' }}
+                      />
+                    </Box>
                   )}
                   <Text fontWeight="bold" fontSize="sm" color="white">
                     {volumeDisplay ?? 'N/A'}

--- a/src/components/collection-page/CollectionStats.tsx
+++ b/src/components/collection-page/CollectionStats.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Divider, Flex, HStack, Image, Skeleton, Text } from '@chakra-ui/react';
+import { Divider, Flex, HStack, Skeleton, Text, Box } from '@chakra-ui/react';
+import Image from 'next/image';
 import { useCollectionStats } from '@/hooks/useCollectionStats';
 
 function InlineStat({ label, value, showIcon }: { label: string; value: string; showIcon?: boolean }) {
@@ -11,7 +12,15 @@ function InlineStat({ label, value, showIcon }: { label: string; value: string; 
       </Text>
       <HStack spacing={1} align="center">
         {showIcon && value !== '-' && value !== 'N/A' && (
-          <Image src="/erc20-icons/usdt0_logo.png" alt="USDT0" boxSize="18px" />
+          <Box position="relative" width="18px" height="18px" flexShrink={0}>
+            <Image 
+              src="/erc20-icons/usdt0_logo.png" 
+              alt="USDT0" 
+              fill
+              sizes="18px"
+              style={{ objectFit: 'contain' }}
+            />
+          </Box>
         )}
         <Text fontSize={{ base: 'lg', md: '2xl' }} fontWeight={800} lineHeight={1.1}>
           {value}


### PR DESCRIPTION
## Hotfix for USDT0 Logo Display

### Problem
- USDT0 logo returning 404 errors in browser console
- Chakra UI Image component not handling public folder images properly in production

### Solution  
- Switch from Chakra's Image to Next.js Image component
- Use proper fill and sizes props for optimized loading
- Wrap in positioned Box containers for proper sizing

### Changes
- Update homepage collection cards to use Next.js Image
- Update collection stats component to use Next.js Image

This ensures the USDT0 logo displays correctly on production (remi.online).

🤖 Generated with Claude Code (https://claude.ai/code)