### PR TITLE
Add official PRETRILLIONS collection and improve drop page UI

### DIFF
--- a/src/components/drop-page/DropClaim.tsx
+++ b/src/components/drop-page/DropClaim.tsx
@@ -595,7 +595,7 @@ export function DropClaim() {
                           textTransform="uppercase"
                           fontSize="sm"
                         >
-                          Public
+                          Active
                         </Text>
                         <Badge
                           colorScheme={statusBadge.colorScheme}
@@ -946,8 +946,8 @@ function ClaimConditionsPanel({
                   align={{ base: 'flex-start', md: 'center' }}
                 >
                   <SimpleGrid columns={{ base: 2, md: 4 }} spacingX={6} spacingY={2} flex="1">
-                    <KeyValue label="Price" value={priceLabel} />
-                    <KeyValue label="Per wallet" value={perWalletValue} />
+                    <KeyValue label="Price" value="Depends on WL" />
+                    <KeyValue label="Per wallet" value="Depends on WL" />
                     <KeyValue label="Access" value={accessLabel} />
                     <KeyValue label="Starts" value={startDisplay} />
                   </SimpleGrid>


### PR DESCRIPTION
## Summary
- Added official PRETRILLIONS collection (0x4633B5f2F84C5506AE3979d1eeB5E58C912CFA5B) with slug 'pretrillions'
- Added test PRETRILLIONS collection (0xB4ab5b0A52432eA35030459958059a7B31E191C4) with slug 'pre-test-final' for testing purposes
- Updated favicon and branding assets with complete favicon suite
- Enhanced collection UI and fixed slug-based routing
- Fixed token page URLs to use clean slugs instead of contract addresses
- Improved drop page UI: changed "Public" title to "Active" for better clarity
- Standardized claim conditions display with "Depends on WL" messaging

## Test plan
- [ ] Verify both collections are accessible via their respective slugs
- [ ] Test drop functionality for both contracts
- [ ] Verify collection browsing works correctly
- [ ] Check favicon displays properly across all devices
- [ ] Test clean URL routing functionality
- [ ] Confirm drop page shows "Active" instead of "Public"
- [ ] Verify claim conditions show "Depends on WL" for price and per wallet

🤖 Generated with [Claude Code](https://claude.ai/code)