### PR TITLE
Clean up collections and improve UI

### DIFF
--- a/src/components/collection-page/CollectionBanner.tsx
+++ b/src/components/collection-page/CollectionBanner.tsx
@@ -18,7 +18,7 @@ export function CollectionBanner() {
         priority
         style={{
           objectFit: 'cover',
-          objectPosition: 'top',
+          objectPosition: 'center 20%',
         }}
         sizes="100vw"
       />

--- a/src/consts/drop_contracts.ts
+++ b/src/consts/drop_contracts.ts
@@ -28,18 +28,6 @@ const baseDropContracts: DropContract[] = [
       1760121600, // 2025-10-10T00:00:00Z
     ],
   },
-  {
-    address: '0xB4ab5b0A52432eA35030459958059a7B31E191C4',
-    chain: plasma,
-    type: 'DropERC721',
-    title: 'PRETRILLIONS Test',
-    description: 'Testing collection for original PRETRILLIONS contract.',
-    thumbnailUrl: NFT_PLACEHOLDER_IMAGE,
-    slug: 'pre-test-final',
-    phaseDeadlines: [
-      1760121600, // 2025-10-10T00:00:00Z
-    ],
-  },
 ];
 
 const testnetDropContracts: DropContract[] = [

--- a/src/consts/nft_contracts.ts
+++ b/src/consts/nft_contracts.ts
@@ -30,15 +30,6 @@ const baseNftContracts: NftContract[] = [
     thumbnailUrl: NFT_PLACEHOLDER_IMAGE,
     slug: 'pretrillions',
   },
-  {
-    address: '0xB4ab5b0A52432eA35030459958059a7B31E191C4',
-    chain: plasma,
-    type: 'ERC721',
-    title: 'PRETRILLIONS Test',
-    description: 'Testing collection for original PRETRILLIONS contract.',
-    thumbnailUrl: NFT_PLACEHOLDER_IMAGE,
-    slug: 'pre-test-final',
-  },
 ];
 
 const testnetNftContracts: NftContract[] = [


### PR DESCRIPTION
## Summary
- Removed test collection (0xB4ab5b0A52432eA35030459958059a7B31E191C4) from both drop and NFT contracts
- Keep only official PRETRILLIONS collection (0x4633B5f2F84C5506AE3979d1eeB5E58C912CFA5B)
- Improved collection banner image positioning from 'top' to 'center 20%' for better visual balance
- Enhanced drop page UI with "Active" title and "Depends on WL" messaging

## Changes
- **Collection cleanup**: Simplified configuration to only official PRETRILLIONS
- **Better header visual**: More balanced image positioning in collection banner
- **Drop page improvements**: Clear "Active" labeling and consistent WL messaging

## Test plan
- [ ] Verify only official PRETRILLIONS collection is visible
- [ ] Test collection page header image positioning looks better
- [ ] Confirm drop functionality works correctly
- [ ] Verify clean URLs and navigation work properly

🤖 Generated with [Claude Code](https://claude.ai/code)